### PR TITLE
style: fix overlapping text when viewing this app

### DIFF
--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -159,7 +159,13 @@ const SearchMovies = () => {
             )}
           </>
         ) : (
-          <Flex as="header" align="center" justify="center" h={{ lg: '80vh' }}>
+          <Flex
+            as="header"
+            align="center"
+            justify="center"
+            h={{ lg: '80vh' }}
+            minH={{ lg: 600 }}
+          >
             <Box textAlign="center">
               <Heading as="h1" size="3xl">
                 Welcome to FilmFinder!


### PR DESCRIPTION
...from an `<iframe>` on an external website.

This change specifically fixes the layout on devices with screen sizes similar to a Surface Pro.